### PR TITLE
Update README.md to include proper hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ To use this project you should:
 
 Contributors
 ============
-Justin Carr (@jhcarr)
+Justin Carr [@jhcarr](github.com/jhcarr/)


### PR DESCRIPTION
This commit updates the contributors section in README.md to correctly use markdown syntax to link to the github user's homepage.
